### PR TITLE
Tentative fix #815 - variable state is undefined when tests run

### DIFF
--- a/tests/pizza-builder.spec.js
+++ b/tests/pizza-builder.spec.js
@@ -9,7 +9,7 @@ const pascalCaseToDashSeparated = (value) =>
 
 const extractAmountFromPrice = (price) => Number(price.replace(/\$ /g, ''));
 
-const getPageState = () => page.evaluate(() => state);
+const getPageState = async () => await page.evaluate(() => state);
 
 // Ironhack Pizza Builder Test-suite
 describe('Ironhack Pizza Builder', () => {


### PR DESCRIPTION

Tentative fixes #815
 
@ross-u I reproduced the issue but inconsistently so I cannot be sure this is a definitive fix.
The reason `state` results undefined could be because of the `let` declaration that causes a TDZ on `state` or also because the `page.reload()` in the `beforeEach()` directive in the test suite causes the sync call to be fired too soon, before the whole script I loaded. If this `async` fix does not work maybe we could protect by waiting until `state !== 'undefined'`

Line 12 is:
https://github.com/ironhack-labs/lab-dom-pizza-builder/blob/1c72182ce5137b5d5dcaae11bd3764b869e0b99d/tests/pizza-builder.spec.js#L12

should be:
https://github.com/MarcoSantonastasi/lab-dom-pizza-builder/blob/85f8a6592b5b14141689dc51c45421b61355cc6c/tests/pizza-builder.spec.js#L12

in fact `getPageState(`) is always called with `await`, therefore it should return a promise explicitly