### PR TITLE
Update the RegEx for number string parsing

### DIFF
--- a/tests/pizza-builder.spec.js
+++ b/tests/pizza-builder.spec.js
@@ -7,7 +7,7 @@ const pascalCaseToDashSeparated = (value) =>
     .join('-')
     .toLowerCase();
 
-const extractAmountFromPrice = (price) => Number(price.replace(/\$ /g, ''));
+const extractAmountFromPrice = (price) => Number(price.replace(/\$/g, ''));
 
 const getPageState = async () => await page.evaluate(() => state);
 


### PR DESCRIPTION
The price test will fail if the total price is set without the space `" "` between the `$` sign and the number. Example:
`$13` - fails
`$ 13`- passes

The update accounts for no space between the string and the `$`. Example:
`$13` - passes
`$ 13`- passes